### PR TITLE
Fixed bug where upload.tool.serial was not properly defined in the board definitions on Arduino IDE 2.x

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -14,7 +14,7 @@ menu.bridge0=Serial Bridge GPIO-0 Pin
 
 dstike.name=DSTIKE WiFi Duck (ATmega32u4)
 
-dstike.upload.tool=avrdude
+dstike.upload.tool.serial=avrdude
 dstike.upload.protocol=avr109
 dstike.upload.maximum_size=28672
 dstike.upload.maximum_data_size=2560
@@ -96,7 +96,7 @@ dstike.menu.debug.serial.build.debug_flags=-DENABLE_DEBUG -DDEBUG_PORT=Serial -D
 
 atmega32u4.name=Generic ATmega32u4
 
-atmega32u4.upload.tool=avrdude
+atmega32u4.upload.tool.serial=avrdude
 atmega32u4.upload.protocol=avr109
 atmega32u4.upload.maximum_size=28672
 atmega32u4.upload.maximum_data_size=2560
@@ -381,7 +381,7 @@ atmega32u4.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 
 leonardo.name=Arduino Leonardo
 
-leonardo.upload.tool=avrdude
+leonardo.upload.tool.serial=avrdude
 leonardo.upload.protocol=avr109
 leonardo.upload.maximum_size=28672
 leonardo.upload.maximum_data_size=2560
@@ -652,7 +652,7 @@ leonardo.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 
 micro.name=Arduino Micro
 
-micro.upload.tool=avrdude
+micro.upload.tool.serial=avrdude
 micro.upload.protocol=avr109
 micro.upload.maximum_size=28672
 micro.upload.maximum_data_size=2560
@@ -931,7 +931,7 @@ micro.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 
 promicro.name=Sparkfun Pro Micro
 
-promicro.upload.tool=avrdude
+promicro.upload.tool.serial=avrdude
 promicro.upload.protocol=avr109
 promicro.upload.maximum_size=28672
 promicro.upload.maximum_data_size=2560
@@ -1168,7 +1168,7 @@ promicro.menu.bridge0.21.build.bridge_0=-DBRIDGE_0=21
 
 cjmcu.name=CJMCU Beetle
 
-cjmcu.upload.tool=avrdude
+cjmcu.upload.tool.serial=avrdude
 cjmcu.upload.protocol=avr109
 cjmcu.upload.maximum_size=28672
 cjmcu.upload.maximum_data_size=2560
@@ -1359,7 +1359,7 @@ cjmcu.menu.bridge0.20.build.bridge_0=-DBRIDGE_0=20
 
 ssmicro.name=SS Micro
 
-ssmicro.upload.tool=avrdude
+ssmicro.upload.tool.serial=avrdude
 ssmicro.upload.protocol=avr109
 ssmicro.upload.maximum_size=28672
 ssmicro.upload.maximum_data_size=2560

--- a/boards.txt
+++ b/boards.txt
@@ -15,6 +15,7 @@ menu.bridge0=Serial Bridge GPIO-0 Pin
 dstike.name=DSTIKE WiFi Duck (ATmega32u4)
 
 dstike.upload.tool.serial=avrdude
+dstike.upload.tool=avrdude
 dstike.upload.protocol=avr109
 dstike.upload.maximum_size=28672
 dstike.upload.maximum_data_size=2560
@@ -97,6 +98,7 @@ dstike.menu.debug.serial.build.debug_flags=-DENABLE_DEBUG -DDEBUG_PORT=Serial -D
 atmega32u4.name=Generic ATmega32u4
 
 atmega32u4.upload.tool.serial=avrdude
+atmega32u4.upload.tool=avrdude
 atmega32u4.upload.protocol=avr109
 atmega32u4.upload.maximum_size=28672
 atmega32u4.upload.maximum_data_size=2560
@@ -382,6 +384,7 @@ atmega32u4.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 leonardo.name=Arduino Leonardo
 
 leonardo.upload.tool.serial=avrdude
+leonardo.upload.tool=avrdude
 leonardo.upload.protocol=avr109
 leonardo.upload.maximum_size=28672
 leonardo.upload.maximum_data_size=2560
@@ -653,6 +656,7 @@ leonardo.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 micro.name=Arduino Micro
 
 micro.upload.tool.serial=avrdude
+micro.upload.tool=avrdude
 micro.upload.protocol=avr109
 micro.upload.maximum_size=28672
 micro.upload.maximum_data_size=2560
@@ -932,6 +936,7 @@ micro.menu.bridge0.23.build.bridge_0=-DBRIDGE_0=23
 promicro.name=Sparkfun Pro Micro
 
 promicro.upload.tool.serial=avrdude
+promicro.upload.tool=avrdude
 promicro.upload.protocol=avr109
 promicro.upload.maximum_size=28672
 promicro.upload.maximum_data_size=2560
@@ -1169,6 +1174,7 @@ promicro.menu.bridge0.21.build.bridge_0=-DBRIDGE_0=21
 cjmcu.name=CJMCU Beetle
 
 cjmcu.upload.tool.serial=avrdude
+cjmcu.upload.tool=avrdude
 cjmcu.upload.protocol=avr109
 cjmcu.upload.maximum_size=28672
 cjmcu.upload.maximum_data_size=2560
@@ -1360,6 +1366,7 @@ cjmcu.menu.bridge0.20.build.bridge_0=-DBRIDGE_0=20
 ssmicro.name=SS Micro
 
 ssmicro.upload.tool.serial=avrdude
+ssmicro.upload.tool=avrdude
 ssmicro.upload.protocol=avr109
 ssmicro.upload.maximum_size=28672
 ssmicro.upload.maximum_data_size=2560


### PR DESCRIPTION
Fixed bug where upload.tool.serial was not properly defined.

This bug is explained more in [this issue](https://github.com/SpacehuhnTech/WiFiDuck/issues/126).  Another pull request ( #1 )  attempted to fix the issue, but only fixed this issue with the DSTIKE board, and this pull request was never merged.